### PR TITLE
Merge v0.1.2 into stable

### DIFF
--- a/GDSerializer.csproj
+++ b/GDSerializer.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Godot.NET.Sdk/3.3.0">
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
         <RootNamespace>Godot.Serialization</RootNamespace>
         <LangVersion>default</LangVersion>
         <Nullable>enable</Nullable>
         <!-- Workaround as Godot does not know how to properly load NuGet packages -->
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.1.1</PackageVersion>
+        <PackageVersion>0.1.2</PackageVersion>
         <Title>GDSerializer</Title>
         <Authors>Carnagion</Authors>
         <Description>An XML (de)serialization framework for Godot's C# API.</Description>
         <RepositoryUrl>https://github.com/Carnagion/GDSerializer</RepositoryUrl>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
         <DocumentationFile>.\.mono\temp\bin\Debug\GDSerializer.xml</DocumentationFile>

--- a/GDSerializer.csproj
+++ b/GDSerializer.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Godot.NET.Sdk/3.3.0">
     <PropertyGroup>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <RootNamespace>Godot.Serialization</RootNamespace>
         <LangVersion>default</LangVersion>
         <Nullable>enable</Nullable>
@@ -12,7 +13,6 @@
         <Description>An XML (de)serialization framework for Godot's C# API.</Description>
         <RepositoryUrl>https://github.com/Carnagion/GDSerializer</RepositoryUrl>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
         <DocumentationFile>.\.mono\temp\bin\Debug\GDSerializer.xml</DocumentationFile>

--- a/ISerializer.cs
+++ b/ISerializer.cs
@@ -12,9 +12,9 @@ namespace Godot.Serialization
         /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
         /// </summary>
         /// <param name="instance">The <see cref="object"/> to serialize.</param>
-        /// <param name="context">The <see cref="XmlDocument"/> to use when creating new <see cref="XmlNode"/>s that will be returned as part of result.</param>
+        /// <param name="type">The <see cref="Type"/> to serialize <paramref name="instance"/> as, in case it is different from <paramref name="instance"/>'s <see cref="Type"/>.</param>
         /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
-        XmlNode Serialize(object instance, XmlDocument? context = null);
+        XmlNode Serialize(object instance, Type? type = null);
         
         /// <summary>
         /// Deserializes <paramref name="node"/> into an <see cref="object"/>.
@@ -22,6 +22,6 @@ namespace Godot.Serialization
         /// <param name="node">The <see cref="XmlNode"/> to deserialize.</param>
         /// <param name="type">The <see cref="Type"/> of <see cref="object"/> to deserialize the node as, in case it is not apparent from <paramref name="node"/>'s attributes.</param>
         /// <returns>An <see cref="object"/> that represents the serialized data stored in <paramref name="node"/>.</returns>
-        object Deserialize(XmlNode node, Type? type = null);
+        object? Deserialize(XmlNode node, Type? type = null);
     }
 }

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -21,7 +21,7 @@ namespace Godot.Serialization
         /// <summary>
         /// An <see cref="OrderedDictionary{TKey,TValue}"/> of specialized <see cref="ISerializer"/>s for specific <see cref="Type"/>s. These serializers will be used by the <see cref="Serializer"/> when possible.
         /// </summary>
-        public static OrderedDictionary<Type, ISerializer> Specialized // Must be static; making it instance will cause a stack overflow due to it being recursively created in inheriting classes
+        public OrderedDictionary<Type, ISerializer> Specialized
         {
             get;
         } = new(19)
@@ -59,7 +59,7 @@ namespace Godot.Serialization
             type ??= instance.GetType();
             
             // Use a more specialized serializer if possible
-            ISerializer? serializer = Serializer.GetSpecialSerializerForType(type);
+            ISerializer? serializer = this.GetSpecialSerializerForType(type);
             if (serializer is not null)
             {
                 return serializer.Serialize(instance, type);
@@ -155,7 +155,7 @@ namespace Godot.Serialization
             type ??= node.GetTypeToDeserialize() ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");
             
             // Use a more specialized deserializer if possible
-            ISerializer? serializer = Serializer.GetSpecialSerializerForType(type);
+            ISerializer? serializer = this.GetSpecialSerializerForType(type);
             if (serializer is not null)
             {
                 return serializer.Deserialize(node, type);
@@ -232,32 +232,32 @@ namespace Godot.Serialization
             return (T?)this.Deserialize(node, typeof(T));
         }
 
-        private static ISerializer? GetSpecialSerializerForType(Type type)
+        private ISerializer? GetSpecialSerializerForType(Type type)
         {
             ISerializer? serializer;
             if (type.IsGenericType)
             {
-                serializer = Serializer.Specialized.GetValueOrDefault(type);
+                serializer = this.Specialized.GetValueOrDefault(type);
                 if (serializer is not null)
                 {
                     return serializer;
                 }
-                Type? match = Serializer.Specialized.Keys
+                Type? match = this.Specialized.Keys
                     .FirstOrDefault(type.IsExactlyGenericType);
                 if (match is not null)
                 {
-                    return Serializer.Specialized[match];
+                    return this.Specialized[match];
                 }
-                match = Serializer.Specialized.Keys
+                match = this.Specialized.Keys
                     .FirstOrDefault(type.DerivesFromGenericType);
                 if (match is not null)
                 {
-                    return Serializer.Specialized[match];
+                    return this.Specialized[match];
                 }
             }
             else
             {
-                Serializer.Specialized.TryGetValue(type, out serializer);
+                this.Specialized.TryGetValue(type, out serializer);
             }
             return serializer;
         }

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -21,7 +21,7 @@ namespace Godot.Serialization
         /// <summary>
         /// An <see cref="OrderedDictionary{TKey,TValue}"/> of specialized <see cref="ISerializer"/>s for specific <see cref="Type"/>s. These serializers will be used by the <see cref="Serializer"/> when possible.
         /// </summary>
-        public static OrderedDictionary<Type, ISerializer> Specialized // Must be static; making it instance will cause a stack overflow due to it being recursively created in inheriting classes
+        public static OrderedDictionary<Type, ISerializer> Specialized // Must be static since other serializers create new Serializer instances, and they all need access to the same dictionary
         {
             get;
         } = new(19)

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -54,7 +54,7 @@ namespace Godot.Serialization
         /// <param name="type">The <see cref="Type"/> to serialize <paramref name="instance"/> as, in case it is different from <paramref name="instance"/>'s <see cref="Type"/>.</param>
         /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
         /// <exception cref="SerializationException">Thrown if <paramref name="instance"/> could not be serialized due to unexpected errors or invalid input.</exception>
-        public virtual XmlNode Serialize(object instance, Type? type = null)
+        public XmlNode Serialize(object instance, Type? type = null)
         {
             type ??= instance.GetType();
             
@@ -145,7 +145,7 @@ namespace Godot.Serialization
         /// <param name="type">The <see cref="Type"/> of <see cref="object"/> to deserialize the node as, in case it is not apparent from <paramref name="node"/>'s attributes.</param>
         /// <returns>An <see cref="object"/> that represents the serialized data stored in <paramref name="node"/>.</returns>
         /// <exception cref="SerializationException">Thrown if a <see cref="Type"/> could not be inferred from <paramref name="node"/> or was invalid, an instance of the <see cref="Type"/> could not be created, <paramref name="node"/> contained invalid properties/fields, or <paramref name="node"/> could not be deserialized due to unexpected errors or invalid data.</exception>
-        public virtual object? Deserialize(XmlNode node, Type? type = null)
+        public object? Deserialize(XmlNode node, Type? type = null)
         {
             if (node.Attributes?["Null"]?.InnerText is "True")
             {

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -51,23 +51,23 @@ namespace Godot.Serialization
         /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
         /// </summary>
         /// <param name="instance">The <see cref="object"/> to serialize.</param>
-        /// <param name="context">The <see cref="XmlDocument"/> to use when creating new <see cref="XmlNode"/>s that will be returned as part of result.</param>
+        /// <param name="type">The <see cref="Type"/> to serialize <paramref name="instance"/> as, in case it is different from <paramref name="instance"/>'s <see cref="Type"/>.</param>
         /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
         /// <exception cref="SerializationException">Thrown if <paramref name="instance"/> could not be serialized due to unexpected errors or invalid input.</exception>
-        public virtual XmlNode Serialize(object instance, XmlDocument? context = null)
+        public virtual XmlNode Serialize(object instance, Type? type = null)
         {
-            Type type = instance.GetType();
+            type ??= instance.GetType();
             
             // Use a more specialized serializer if possible
             ISerializer? serializer = Serializer.GetSpecialSerializerForType(type);
             if (serializer is not null)
             {
-                return serializer.Serialize(instance, context);
+                return serializer.Serialize(instance, type);
             }
 
             try
             {
-                context ??= new();
+                XmlDocument context = new();
                 XmlElement element;
                 // Use the "Type" attribute if generic or nested type as ` and + are not allowed as XML node names
                 if (type.IsGenericType)
@@ -96,9 +96,9 @@ namespace Godot.Serialization
                         continue;
                     }
                     XmlNode node = context.CreateElement(property.Name);
-                    this.Serialize(value, context).ChildNodes
+                    this.Serialize(value, property.PropertyType).ChildNodes
                         .Cast<XmlNode>()
-                        .ForEach(child => node.AppendChild(child));
+                        .ForEach(child => node.AppendChild(context.ImportNode(child, true)));
                     element.AppendChild(node);
                 }
                 
@@ -113,9 +113,9 @@ namespace Godot.Serialization
                         continue;
                     }
                     XmlNode node= context.CreateElement(field.Name);
-                    this.Serialize(value, context).ChildNodes
+                    this.Serialize(value, field.FieldType).ChildNodes
                         .Cast<XmlNode>()
-                        .ForEach(child => node.AppendChild(child));
+                        .ForEach(child => node.AppendChild(context.ImportNode(child, true)));
                     element.AppendChild(node);
                 }
 
@@ -128,14 +128,30 @@ namespace Godot.Serialization
         }
 
         /// <summary>
+        /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
+        /// </summary>
+        /// <param name="instance">The <see cref="object"/> to serialize.</param>
+        /// <typeparam name="T">The <see cref="Type"/> to serialize <paramref name="instance"/> as.</typeparam>
+        /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
+        public XmlNode Serialize<T>(T instance) where T : notnull
+        {
+            return this.Serialize(instance, typeof(T));
+        }
+
+        /// <summary>
         /// Deserializes <paramref name="node"/> into an <see cref="object"/>.
         /// </summary>
         /// <param name="node">The <see cref="XmlNode"/> to deserialize.</param>
         /// <param name="type">The <see cref="Type"/> of <see cref="object"/> to deserialize the node as, in case it is not apparent from <paramref name="node"/>'s attributes.</param>
         /// <returns>An <see cref="object"/> that represents the serialized data stored in <paramref name="node"/>.</returns>
         /// <exception cref="SerializationException">Thrown if a <see cref="Type"/> could not be inferred from <paramref name="node"/> or was invalid, an instance of the <see cref="Type"/> could not be created, <paramref name="node"/> contained invalid properties/fields, or <paramref name="node"/> could not be deserialized due to unexpected errors or invalid data.</exception>
-        public virtual object Deserialize(XmlNode node, Type? type = null)
+        public virtual object? Deserialize(XmlNode node, Type? type = null)
         {
+            if (node.Attributes?["Null"]?.InnerText is "True")
+            {
+                return null;
+            }
+            
             type ??= Serializer.GetTypeToDeserialize(node) ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");
             
             // Use a more specialized deserializer if possible
@@ -211,12 +227,17 @@ namespace Godot.Serialization
         /// <param name="node">The <see cref="XmlNode"/> to deserialize.</param>
         /// <typeparam name="T">The <see cref="Type"/> of <see cref="object"/> to deserialize <paramref name="node"/> as.</typeparam>
         /// <returns>An <see cref="object"/> that represents the serialized data stored in <paramref name="node"/>.</returns>
-        public T Deserialize<T>(XmlNode node)
+        public T? Deserialize<T>(XmlNode node)
         {
-            return (T)this.Deserialize(node, typeof(T));
+            return (T?)this.Deserialize(node, typeof(T));
         }
-
-        private static Type? GetTypeToDeserialize(XmlNode node)
+        
+        /// <summary>
+        /// Tries to find a suitable <see cref="Type"/> to deserialize <paramref name="node"/> as.
+        /// </summary>
+        /// <param name="node">The <see cref="XmlNode"/> to deserialize.</param>
+        /// <returns>The <see cref="Type"/> of the serialized data in <paramref name="node"/>, or <see langword="null"/> if no suitable <see cref="Type"/> was found.</returns>
+        protected static Type? GetTypeToDeserialize(XmlNode node)
         {
             string name = (node.Attributes?["Type"]?.InnerText ?? node.Name)
                 .Replace("&lt;", "<")

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -152,7 +152,7 @@ namespace Godot.Serialization
                 return null;
             }
             
-            type ??= Serializer.GetTypeToDeserialize(node) ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");
+            type ??= node.GetTypeToDeserialize() ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");
             
             // Use a more specialized deserializer if possible
             ISerializer? serializer = Serializer.GetSpecialSerializerForType(type);
@@ -230,22 +230,6 @@ namespace Godot.Serialization
         public T? Deserialize<T>(XmlNode node)
         {
             return (T?)this.Deserialize(node, typeof(T));
-        }
-        
-        /// <summary>
-        /// Tries to find a suitable <see cref="Type"/> to deserialize <paramref name="node"/> as.
-        /// </summary>
-        /// <param name="node">The <see cref="XmlNode"/> to deserialize.</param>
-        /// <returns>The <see cref="Type"/> of the serialized data in <paramref name="node"/>, or <see langword="null"/> if no suitable <see cref="Type"/> was found.</returns>
-        protected static Type? GetTypeToDeserialize(XmlNode node)
-        {
-            string name = (node.Attributes?["Type"]?.InnerText ?? node.Name)
-                .Replace("&lt;", "<")
-                .Replace("&gt;", ">");
-            return (from assembly in AppDomain.CurrentDomain.GetAssemblies().Distinct()
-                    select assembly.GetType(name))
-                .NotNull()
-                .FirstOrDefault();
         }
 
         private static ISerializer? GetSpecialSerializerForType(Type type)

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -86,7 +86,7 @@ namespace Godot.Serialization
                 }
 
                 // Recursively serialize properties
-                foreach (PropertyInfo property in from property in type.GetProperties(Serializer.instanceBindingFlags)
+                foreach (PropertyInfo property in from property in type.GetAllProperties(Serializer.instanceBindingFlags)
                                                   where property.IsSerializable()
                                                   select property)
                 {
@@ -103,7 +103,7 @@ namespace Godot.Serialization
                 }
                 
                 // Recursively serialize fields
-                foreach (FieldInfo field in from field in type.GetFields(Serializer.instanceBindingFlags)
+                foreach (FieldInfo field in from field in type.GetAllFields(Serializer.instanceBindingFlags)
                                             where field.IsSerializable()
                                             select field)
                 {
@@ -171,7 +171,7 @@ namespace Godot.Serialization
                                           select child)
                 {
                     // Recursively deserialize property
-                    PropertyInfo? property = type.GetProperty(child.Name, Serializer.instanceBindingFlags);
+                    PropertyInfo? property = type.FindProperty(child.Name, Serializer.instanceBindingFlags);
                     if (property is not null)
                     {
                         if (!property.CanWrite)
@@ -188,7 +188,7 @@ namespace Godot.Serialization
                     }
                 
                     // Recursively deserialize field
-                    FieldInfo? field = type.GetField(child.Name, Serializer.instanceBindingFlags);
+                    FieldInfo? field = type.FindField(child.Name, Serializer.instanceBindingFlags);
                     if (field is not null)
                     {
                         if (!field.GetCustomAttribute<SerializeAttribute>()?.Serializable ?? false)

--- a/Specialized/CollectionSerializer.cs
+++ b/Specialized/CollectionSerializer.cs
@@ -22,7 +22,7 @@ namespace Godot.Serialization.Specialized
         /// <param name="collectionType">The <see cref="Type"/> to serialize <paramref name="instance"/> as.</param>
         /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
         /// <exception cref="SerializationException">Thrown if <paramref name="instance"/> could not be serialized due to unexpected errors or invalid input.</exception>
-        public XmlNode Serialize(object instance, Type? collectionType = null)
+        public virtual XmlNode Serialize(object instance, Type? collectionType = null)
         {
             collectionType ??= instance.GetType();
             if (!collectionType.DerivesFromGenericType(typeof(ICollection<>)))
@@ -63,7 +63,7 @@ namespace Godot.Serialization.Specialized
         /// <param name="collectionType">The <see cref="Type"/> of <see cref="object"/> to deserialize the node as. It must implement <see cref="ICollection{T}"/>.</param>
         /// <returns>An <see cref="object"/> that represents the serialized data stored in <paramref name="node"/>.</returns>
         /// <exception cref="SerializationException">Thrown if <paramref name="node"/> could not be deserialized due to unexpected errors or invalid input.</exception>
-        public object Deserialize(XmlNode node, Type? collectionType = null)
+        public virtual object Deserialize(XmlNode node, Type? collectionType = null)
         {
             collectionType ??= node.GetTypeToDeserialize() ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");
             if (!collectionType.DerivesFromGenericType(typeof(ICollection<>)))

--- a/Specialized/DictionarySerializer.cs
+++ b/Specialized/DictionarySerializer.cs
@@ -19,24 +19,28 @@ namespace Godot.Serialization.Specialized
         /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
         /// </summary>
         /// <param name="instance">The <see cref="object"/> to serialize. It must implement <see cref="IDictionary{TKey,TValue}"/>.</param>
-        /// <param name="context">The <see cref="XmlDocument"/> to use when creating new <see cref="XmlNode"/>s that will be returned as part of result.</param>
+        /// <param name="dictionaryType">The <see cref="Type"/> to serialize <paramref name="instance"/> as.</param>
         /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
         /// <exception cref="SerializationException">Thrown if <paramref name="instance"/> could not be serialized due to unexpected errors or invalid input.</exception>
-        public override XmlNode Serialize(object instance, XmlDocument? context = null)
+        public override XmlNode Serialize(object instance, Type? dictionaryType = null)
         {
-            Type dictionaryType = instance.GetType();
+            dictionaryType ??= instance.GetType();
             if (!dictionaryType.DerivesFromGenericType(typeof(IDictionary<,>)))
             {
                 throw new SerializationException(instance, $"\"{dictionaryType.GetDisplayName()}\" cannot be (de)serialized by {typeof(DictionarySerializer).GetDisplayName()}");
             }
-
+            
             try
             {
+                Type keyType = dictionaryType.GenericTypeArguments[0];
+                Type valueType = dictionaryType.GenericTypeArguments[1];
+                
                 Type pairType = typeof(KeyValuePair<,>).MakeGenericType(dictionaryType.GenericTypeArguments);
+                
                 PropertyInfo keyProperty = pairType.GetProperty("Key")!;
                 PropertyInfo valueProperty = pairType.GetProperty("Value")!;
             
-                context ??= new();
+                XmlDocument context = new();
                 XmlElement dictionaryElement = context.CreateElement("Dictionary");
                 dictionaryElement.SetAttribute("Type", dictionaryType.FullName);
                 foreach (object item in (IEnumerable)instance)
@@ -44,14 +48,18 @@ namespace Godot.Serialization.Specialized
                     XmlElement itemElement = context.CreateElement("item");
                     XmlElement keyElement = context.CreateElement("key");
                     XmlElement valueElement = context.CreateElement("value");
+                    
                     object key = keyProperty.GetValue(item)!;
                     object value = valueProperty.GetValue(item)!;
-                    base.Serialize(key, context).ChildNodes
+                    
+                    base.Serialize(key, keyType).ChildNodes
                         .Cast<XmlNode>()
-                        .ForEach(node => keyElement.AppendChild(node));
-                    base.Serialize(value, context).ChildNodes
+                        .ForEach(node => keyElement.AppendChild(context.ImportNode(node, true)));
+                    
+                    base.Serialize(value, valueType).ChildNodes
                         .Cast<XmlNode>()
-                        .ForEach(node => valueElement.AppendChild(node));
+                        .ForEach(node => valueElement.AppendChild(context.ImportNode(node, true)));
+                    
                     itemElement.AppendChild(keyElement);
                     itemElement.AppendChild(valueElement);
                     dictionaryElement.AppendChild(itemElement);
@@ -74,11 +82,7 @@ namespace Godot.Serialization.Specialized
         /// <exception cref="SerializationException">Thrown if <paramref name="node"/> could not be deserialized due to unexpected errors or invalid input.</exception>
         public override object Deserialize(XmlNode node, Type? dictionaryType = null)
         {
-            if (dictionaryType is null)
-            {
-                throw new SerializationException(node, $"{nameof(Type)} not provided");
-            }
-
+            dictionaryType ??= DictionarySerializer.GetTypeToDeserialize(node) ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");
             if (!dictionaryType.DerivesFromGenericType(typeof(IDictionary<,>)))
             {
                 throw new SerializationException(node, $"\"{dictionaryType.GetDisplayName()}\" cannot be (de)serialized by {typeof(CollectionSerializer).GetDisplayName()}");
@@ -86,7 +90,6 @@ namespace Godot.Serialization.Specialized
 
             try
             {
-                MethodInfo add = dictionaryType.GetMethod("Add")!;
                 Type keyType = dictionaryType.GenericTypeArguments[0];
                 Type valueType = dictionaryType.GenericTypeArguments[1];
 
@@ -94,6 +97,8 @@ namespace Godot.Serialization.Specialized
                 {
                     dictionaryType = typeof(Dictionary<,>).MakeGenericType(keyType, valueType);
                 }
+                
+                MethodInfo add = dictionaryType.GetMethod("Add")!;
 
                 object dictionary = Activator.CreateInstance(dictionaryType, true) ?? throw new SerializationException(node, $"Unable to instantiate {dictionaryType.GetDisplayName()}");
                 foreach (XmlNode child in from XmlNode child in node.ChildNodes
@@ -107,10 +112,10 @@ namespace Godot.Serialization.Specialized
 
                     XmlNode key = child.ChildNodes
                         .Cast<XmlNode>()
-                        .FirstOrDefault(grandchild => grandchild.Name == "key") ?? throw new SerializationException(child, "No key node present");
+                        .SingleOrDefault(grandchild => grandchild.Name == "key") ?? throw new SerializationException(child, "No key node present");
                     XmlNode value = child.ChildNodes
                         .Cast<XmlNode>()
-                        .FirstOrDefault(grandchild => grandchild.Name == "value") ?? throw new SerializationException(child, "No value node present");
+                        .SingleOrDefault(grandchild => grandchild.Name == "value") ?? throw new SerializationException(child, "No value node present");
 
                     add.Invoke(dictionary, new[] {base.Deserialize(key, keyType), base.Deserialize(value, valueType),});
                 }

--- a/Specialized/EnumerableSerializer.cs
+++ b/Specialized/EnumerableSerializer.cs
@@ -12,7 +12,7 @@ namespace Godot.Serialization.Specialized
     /// <summary>
     /// A (de)serializer for <see cref="IEnumerable{T}"/>.
     /// </summary>
-    public class EnumerableSerializer : Serializer
+    public class EnumerableSerializer : ISerializer
     {
         /// <summary>
         /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
@@ -21,7 +21,7 @@ namespace Godot.Serialization.Specialized
         /// <param name="enumerableType">The <see cref="Type"/> to serialize <paramref name="instance"/> as.</param>
         /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
         /// <exception cref="SerializationException">Thrown if <paramref name="instance"/> could not be serialized due to unexpected errors or invalid input.</exception>
-        public override XmlNode Serialize(object instance, Type? enumerableType = null)
+        public XmlNode Serialize(object instance, Type? enumerableType = null)
         {
             enumerableType ??= instance.GetType();
             if (!enumerableType.IsExactlyGenericType(typeof(IEnumerable<>)))
@@ -36,10 +36,13 @@ namespace Godot.Serialization.Specialized
                 XmlDocument context = new();
                 XmlElement enumerableElement = context.CreateElement("Enumerable");
                 enumerableElement.SetAttribute("Type", enumerableType.FullName);
+
+                Serializer serializer = new();
+                
                 foreach (object item in (IEnumerable)instance)
                 {
                     XmlElement itemElement = context.CreateElement("item");
-                    base.Serialize(item, itemType).ChildNodes
+                    serializer.Serialize(item, itemType).ChildNodes
                         .Cast<XmlNode>()
                         .ForEach(node => itemElement.AppendChild(context.ImportNode(node, true)));
                     enumerableElement.AppendChild(itemElement);
@@ -59,9 +62,9 @@ namespace Godot.Serialization.Specialized
         /// <param name="enumerableType">The <see cref="Type"/> of <see cref="object"/> to deserialize the node as. It must be exactly <see cref="IEnumerable{T}"/>.</param>
         /// <returns>An <see cref="object"/> that represents the serialized data stored in <paramref name="node"/>.</returns>
         /// <exception cref="SerializationException">Thrown if <paramref name="node"/> could not be deserialized due to unexpected errors or invalid input.</exception>
-        public override object Deserialize(XmlNode node, Type? enumerableType = null)
+        public object Deserialize(XmlNode node, Type? enumerableType = null)
         {
-            enumerableType ??= EnumerableSerializer.GetTypeToDeserialize(node) ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");
+            enumerableType ??= node.GetTypeToDeserialize() ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");
             if (!enumerableType.IsExactlyGenericType(typeof(IEnumerable<>)))
             {
                 throw new SerializationException(node, $"\"{enumerableType.GetDisplayName()}\" cannot be (de)serialized by {typeof(EnumerableSerializer).GetDisplayName()}");
@@ -71,7 +74,7 @@ namespace Godot.Serialization.Specialized
             {
                 Type itemType = enumerableType.GenericTypeArguments[0];
                 Type listType = typeof(List<>).MakeGenericType(itemType);
-                object enumerable = new CollectionSerializer().Deserialize(node, listType); // Cannot use base.Deserialize() here as List<T> implements both ICollection<T> and IEnumerable<T>, and Serializer's dictionary is not sorted so IEnumerable<T> may be picked leading to infinite recursive calls
+                object enumerable = new CollectionSerializer().Deserialize(node, listType);
                 return typeof(IEnumerableExtensions).GetMethod("Copy")!.MakeGenericMethod(itemType).Invoke(null, new[] {enumerable,})!;
             }
             catch (Exception exception) when (exception is not SerializationException)

--- a/Specialized/EnumerableSerializer.cs
+++ b/Specialized/EnumerableSerializer.cs
@@ -12,7 +12,7 @@ namespace Godot.Serialization.Specialized
     /// <summary>
     /// A (de)serializer for <see cref="IEnumerable{T}"/>.
     /// </summary>
-    public class EnumerableSerializer : ISerializer
+    public class EnumerableSerializer : CollectionSerializer
     {
         /// <summary>
         /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
@@ -21,7 +21,7 @@ namespace Godot.Serialization.Specialized
         /// <param name="enumerableType">The <see cref="Type"/> to serialize <paramref name="instance"/> as.</param>
         /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
         /// <exception cref="SerializationException">Thrown if <paramref name="instance"/> could not be serialized due to unexpected errors or invalid input.</exception>
-        public XmlNode Serialize(object instance, Type? enumerableType = null)
+        public override XmlNode Serialize(object instance, Type? enumerableType = null)
         {
             enumerableType ??= instance.GetType();
             if (!enumerableType.IsExactlyGenericType(typeof(IEnumerable<>)))
@@ -62,7 +62,7 @@ namespace Godot.Serialization.Specialized
         /// <param name="enumerableType">The <see cref="Type"/> of <see cref="object"/> to deserialize the node as. It must be exactly <see cref="IEnumerable{T}"/>.</param>
         /// <returns>An <see cref="object"/> that represents the serialized data stored in <paramref name="node"/>.</returns>
         /// <exception cref="SerializationException">Thrown if <paramref name="node"/> could not be deserialized due to unexpected errors or invalid input.</exception>
-        public object Deserialize(XmlNode node, Type? enumerableType = null)
+        public override object Deserialize(XmlNode node, Type? enumerableType = null)
         {
             enumerableType ??= node.GetTypeToDeserialize() ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");
             if (!enumerableType.IsExactlyGenericType(typeof(IEnumerable<>)))
@@ -74,7 +74,7 @@ namespace Godot.Serialization.Specialized
             {
                 Type itemType = enumerableType.GenericTypeArguments[0];
                 Type listType = typeof(List<>).MakeGenericType(itemType);
-                object enumerable = new CollectionSerializer().Deserialize(node, listType);
+                object enumerable = base.Deserialize(node, listType);
                 return typeof(IEnumerableExtensions).GetMethod("Copy")!.MakeGenericMethod(itemType).Invoke(null, new[] {enumerable,})!;
             }
             catch (Exception exception) when (exception is not SerializationException)

--- a/Specialized/SimpleSerializer.cs
+++ b/Specialized/SimpleSerializer.cs
@@ -18,19 +18,19 @@ namespace Godot.Serialization.Specialized
         /// Serializes the simple type <paramref name="instance"/> into an <see cref="XmlNode"/>.
         /// </summary>
         /// <param name="instance">The <see cref="object"/> to serialize. Its <see cref="Type"/> must be one of <see cref="string"/>, <see cref="char"/>, <see cref="bool"/>, or the numeric types(<see cref="int"/>, <see cref="float"/>, etc).</param>
-        /// <param name="context">The <see cref="XmlDocument"/> to use when creating new <see cref="XmlNode"/>s that will be returned as part of result.</param>
+        /// <param name="type">The <see cref="Type"/> to serialize <paramref name="instance"/> as, in case it is different from <paramref name="instance"/>'s <see cref="Type"/>.</param>
         /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
         /// <exception cref="SerializationException">Thrown if <paramref name="instance"/>'s <see cref="Type"/> is not a simple type.</exception>
-        public XmlNode Serialize(object instance, XmlDocument? context = null)
+        public XmlNode Serialize(object instance, Type? type = null)
         {
-            Type type = instance.GetType();
+            type ??= instance.GetType();
             if (!SimpleSerializer.simpleTypes.Contains(type))
             {
                 throw new SerializationException(instance, $"\"{type.GetDisplayName()}\" is not a suitable {nameof(Type)} for {typeof(SimpleSerializer).GetDisplayName()}");
             }
 
-            context ??= new();
-            XmlElement element = context.CreateElement(type.GetDisplayName()!);
+            XmlDocument context = new();
+            XmlElement element = context.CreateElement(type.GetDisplayName());
             element.AppendChild(context.CreateTextNode(instance.ToString()));
             return element;
         }

--- a/Specialized/VectorSerializer.cs
+++ b/Specialized/VectorSerializer.cs
@@ -23,12 +23,12 @@ namespace Godot.Serialization.Specialized
         /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
         /// </summary>
         /// <param name="instance">The <see cref="object"/> to serialize. It must be a <see cref="Vector2"/> or <see cref="Vector3"/>.</param>
-        /// <param name="context">The <see cref="XmlDocument"/> to use when creating new <see cref="XmlNode"/>s that will be returned as part of result.</param>
+        /// <param name="vectorType">The <see cref="Type"/> to serialize <paramref name="instance"/> as. This parameter is ignored by <see cref="VectorSerializer"/>.</param>
         /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
         /// <exception cref="SerializationException">Thrown if <paramref name="instance"/> is not a <see cref="Vector2"/> or <see cref="Vector3"/>.</exception>
-        public XmlNode Serialize(object instance, XmlDocument? context = null)
+        public XmlNode Serialize(object instance, Type? vectorType = null)
         {
-            context ??= new();
+            XmlDocument context = new();
             switch (instance)
             {
                 case Vector2 vector2:

--- a/Utility/Extensions/TypeExtensions.cs
+++ b/Utility/Extensions/TypeExtensions.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 using Microsoft.CSharp;
 
@@ -56,6 +58,52 @@ namespace Godot.Serialization.Utility.Extensions
         {
             using CSharpCodeProvider provider = new();
             return provider.GetTypeOutput(new(type));
+        }
+
+        /// <summary>
+        /// Retrieves all fields defined in <paramref name="type"/> as well as its base <see cref="Type"/>s using <paramref name="flags"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to search in.</param>
+        /// <param name="flags">The binding constraints.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of fields defined in <paramref name="type"/> and its base <see cref="Type"/>s.</returns>
+        public static IEnumerable<FieldInfo> GetAllFields(this Type type, BindingFlags flags = BindingFlags.Default)
+        {
+            return type.BaseType is null ? type.GetFields(flags) : type.GetFields(flags).Concat(type.BaseType.GetAllFields(flags));
+        }
+
+        /// <summary>
+        /// Retrieves all properties defined in <paramref name="type"/> as well as its base <see cref="Type"/>s using <paramref name="flags"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to search in.</param>
+        /// <param name="flags">The binding constraints.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of properties defined in <paramref name="type"/> and its base <see cref="Type"/>s.</returns>
+        public static IEnumerable<PropertyInfo> GetAllProperties(this Type type, BindingFlags flags = BindingFlags.Default)
+        {
+            return type.BaseType is null ? type.GetProperties(flags) : type.GetProperties(flags).Concat(type.BaseType.GetAllProperties(flags));
+        }
+
+        /// <summary>
+        /// Searches for the specified field in <paramref name="type"/> and its base <see cref="Type"/>s.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to search in.</param>
+        /// <param name="name">The name of the field.</param>
+        /// <param name="flags">The binding constraints.</param>
+        /// <returns>A <see cref="FieldInfo"/> representing the field matching the specified name and constraints, or <see langword="null"/> if no match was found.</returns>
+        public static FieldInfo? FindField(this Type type, string name, BindingFlags flags = BindingFlags.Default)
+        {
+            return type.GetField(name, flags) ?? type.BaseType?.FindField(name, flags);
+        }
+
+        /// <summary>
+        /// Searches for the specified property in <paramref name="type"/> and its base <see cref="Type"/>s.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to search in.</param>
+        /// <param name="name">The name of the property.</param>
+        /// <param name="flags">The binding constraints.</param>
+        /// <returns>A <see cref="PropertyInfo"/> representing the property matching the specified name and constraints, or <see langword="null"/> if no match was found.</returns>
+        public static PropertyInfo? FindProperty(this Type type, string name, BindingFlags flags = BindingFlags.Default)
+        {
+            return type.GetProperty(name, flags) ?? type.BaseType?.FindProperty(name, flags);
         }
     }
 }

--- a/Utility/Extensions/XmlNodeExtensions.cs
+++ b/Utility/Extensions/XmlNodeExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+using System.Xml;
+
+namespace Godot.Serialization.Utility.Extensions
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="XmlNode"/>.
+    /// </summary>
+    public static class XmlNodeExtensions
+    {
+        /// <summary>
+        /// Tries to find a suitable <see cref="Type"/> to deserialize <paramref name="node"/> as.
+        /// </summary>
+        /// <param name="node">The <see cref="XmlNode"/> to deserialize.</param>
+        /// <returns>The <see cref="Type"/> of the serialized data in <paramref name="node"/>, or <see langword="null"/> if no suitable <see cref="Type"/> was found.</returns>
+        public static Type? GetTypeToDeserialize(this XmlNode node)
+        {
+            string name = (node.Attributes?["Type"]?.InnerText ?? node.Name)
+                .Replace("&lt;", "<")
+                .Replace("&gt;", ">");
+            return (from assembly in AppDomain.CurrentDomain.GetAssemblies().Distinct()
+                    select assembly.GetType(name))
+                .NotNull()
+                .FirstOrDefault();
+        }
+    }
+}

--- a/Utility/OrderedDictionary.cs
+++ b/Utility/OrderedDictionary.cs
@@ -84,22 +84,6 @@ namespace Godot.Serialization.Utility
             }
         }
 
-        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys
-        {
-            get
-            {
-                return this.Keys;
-            }
-        }
-
-        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values
-        {
-            get
-            {
-                return this.Values;
-            }
-        }
-
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly
         {
             get


### PR DESCRIPTION
# Changes
- Update `Serialize(object, XmlDocument?)` to be `Serialize(object, Type?)` instead
  - Use `XmlDocument.CloneNode(XmlNode)` to add XML nodes where necessary rather than passing around `XmlDocument` references
- Change `GetTypeToDeserialize(XmlNode)` to an extension method to make it available globally

# Bugfixes
- Fix recursion issues with virtual methods in serializer types by removing inheritance
  - Serializers now create other new serializers if necessary, except for `EnumerableSerializer`, which inherits from `CollectionSerializer`