### PR TITLE
Merge v0.2.0 into stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GDSerializer is available as a [NuGet package](https://www.nuget.org/packages/GD
 Simply include the following lines in a Godot project's `.csproj` file (either by editing the file manually or letting an IDE install the package):  
 ```xml
 <ItemGroup>
-    <PackageReference Include="GDSerializer" Version="0.1.3" />
+    <PackageReference Include="GDSerializer" Version="0.2.0" />
 </ItemGroup>
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GDSerializer is available as a [NuGet package](https://www.nuget.org/packages/GD
 Simply include the following lines in a Godot project's `.csproj` file (either by editing the file manually or letting an IDE install the package):  
 ```xml
 <ItemGroup>
-    <PackageReference Include="GDSerializer" Version="0.1.1" />
+    <PackageReference Include="GDSerializer" Version="0.1.3" />
 </ItemGroup>
 ```
 

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -40,6 +40,7 @@ namespace Godot.Serialization
             {typeof(float), new SimpleSerializer()},
             {typeof(double), new SimpleSerializer()},
             {typeof(decimal), new SimpleSerializer()},
+            {typeof(Array), new ArraySerializer()},
             {typeof(IDictionary<,>), new DictionarySerializer()},
             {typeof(ICollection<>), new CollectionSerializer()},
             {typeof(IEnumerable<>), new EnumerableSerializer()},

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -234,22 +234,15 @@ namespace Godot.Serialization
 
         private static ISerializer? GetSpecialSerializerForType(Type type)
         {
-            ISerializer? serializer;
+            ISerializer? serializer = Serializer.Specialized.GetValueOrDefault(type);
+            if (serializer is not null)
+            {
+                return serializer;
+            }
             if (type.IsGenericType)
             {
-                serializer = Serializer.Specialized.GetValueOrDefault(type);
-                if (serializer is not null)
-                {
-                    return serializer;
-                }
-                Type? match = Serializer.Specialized.Keys
-                    .FirstOrDefault(type.IsExactlyGenericType);
-                if (match is not null)
-                {
-                    return Serializer.Specialized[match];
-                }
-                match = Serializer.Specialized.Keys
-                    .FirstOrDefault(type.DerivesFromGenericType);
+                Type? match = Serializer.Specialized.Keys.FirstOrDefault(type.IsExactlyGenericType);
+                match ??= Serializer.Specialized.Keys.FirstOrDefault(type.DerivesFromGenericType);
                 if (match is not null)
                 {
                     return Serializer.Specialized[match];
@@ -257,7 +250,11 @@ namespace Godot.Serialization
             }
             else
             {
-                Serializer.Specialized.TryGetValue(type, out serializer);
+                Type? match = Serializer.Specialized.Keys.FirstOrDefault(key => key.IsAssignableFrom(type));
+                if (match is not null)
+                {
+                    serializer = Serializer.Specialized[match];
+                }
             }
             return serializer;
         }

--- a/Specialized/ArraySerializer.cs
+++ b/Specialized/ArraySerializer.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Xml;
+
+using Godot.Serialization.Utility.Exceptions;
+using Godot.Serialization.Utility.Extensions;
+
+namespace Godot.Serialization.Specialized
+{
+    public class ArraySerializer : CollectionSerializer
+    {
+        public override XmlNode Serialize(object instance, Type? arrayType = null)
+        {
+            arrayType ??= instance.GetType();
+            if (!arrayType.IsArray)
+            {
+                throw new SerializationException(instance, $"\"{arrayType.GetDisplayName()}\" cannot be serialized by {typeof(ArraySerializer).GetDisplayName()}");
+            }
+
+            try
+            {
+                Type itemType = arrayType.GetElementType()!;
+
+                XmlDocument context = new();
+                XmlElement arrayElement = context.CreateElement("Array");
+                arrayElement.SetAttribute("Type", arrayType.FullName);
+                ArraySerializer.SerializeItems(instance, itemType).ForEach(node => arrayElement.AppendChild(context.ImportNode(node, true)));
+                return arrayElement;
+            }
+            catch (Exception exception) when (exception is not SerializationException)
+            {
+                throw new SerializationException(instance, exception);
+            }
+        }
+
+        public override object Deserialize(XmlNode node, Type? arrayType = null)
+        {
+            arrayType ??= node.GetTypeToDeserialize() ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");
+            if (!arrayType.IsArray)
+            {
+                throw new SerializationException(node, $"\"{arrayType.GetDisplayName()}\" cannot be deserialized by {typeof(ArraySerializer).GetDisplayName()}");
+            }
+
+            try
+            {
+                Type itemType = arrayType.GetElementType()!;
+
+                IList array = Array.CreateInstance(itemType, node.ChildNodes.Count);
+                int index = 0;
+                foreach (object? item in ArraySerializer.DeserializeItems(node, itemType))
+                {
+                    array[index] = item;
+                    index += 1;
+                }
+                return array;
+            }
+            catch (Exception exception) when (exception is not SerializationException)
+            {
+                throw new SerializationException(node, exception);
+            }
+        }
+    }
+}

--- a/Specialized/ArraySerializer.cs
+++ b/Specialized/ArraySerializer.cs
@@ -8,8 +8,18 @@ using Godot.Serialization.Utility.Extensions;
 
 namespace Godot.Serialization.Specialized
 {
+    /// <summary>
+    /// A (de)serializer for arrays.
+    /// </summary>
     public class ArraySerializer : CollectionSerializer
     {
+        /// <summary>
+        /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
+        /// </summary>
+        /// <param name="instance">The <see cref="object"/> to serialize. It must be an array.</param>
+        /// <param name="arrayType">The <see cref="Type"/> to serialize <paramref name="instance"/> as. It must be an array type.</param>
+        /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
+        /// <exception cref="SerializationException">Thrown if <paramref name="instance"/> could not be serialized due to unexpected errors or invalid input.</exception>
         public override XmlNode Serialize(object instance, Type? arrayType = null)
         {
             arrayType ??= instance.GetType();
@@ -33,7 +43,14 @@ namespace Godot.Serialization.Specialized
                 throw new SerializationException(instance, exception);
             }
         }
-
+        
+        /// <summary>
+        /// Deserializes <paramref name="node"/> into an <see cref="object"/>.
+        /// </summary>
+        /// <param name="node">The <see cref="XmlNode"/> to deserialize.</param>
+        /// <param name="arrayType">The <see cref="Type"/> of <see cref="object"/> to deserialize the node as. It must be an array type</param>
+        /// <returns>An <see cref="object"/> that represents the serialized data stored in <paramref name="node"/>.</returns>
+        /// <exception cref="SerializationException">Thrown if a <see cref="Type"/> could not be inferred from <paramref name="node"/> or was invalid, an instance of the <see cref="Type"/> could not be created, <paramref name="node"/> contained invalid properties/fields, or <paramref name="node"/> could not be deserialized due to unexpected errors or invalid data.</exception>
         public override object Deserialize(XmlNode node, Type? arrayType = null)
         {
             arrayType ??= node.GetTypeToDeserialize() ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");

--- a/Specialized/CollectionSerializer.cs
+++ b/Specialized/CollectionSerializer.cs
@@ -43,7 +43,11 @@ namespace Godot.Serialization.Specialized
                 foreach (object item in (IEnumerable)instance)
                 {
                     XmlElement itemElement = context.CreateElement("item");
-                    serializer.Serialize(item, itemType).ChildNodes
+                    if (item.GetType() != itemType)
+                    {
+                        itemElement.SetAttribute("Type", item.GetType().FullName);
+                    }
+                    serializer.Serialize(item, item.GetType()).ChildNodes
                         .Cast<XmlNode>()
                         .ForEach(node => itemElement.AppendChild(node));
                     collectionElement.AppendChild(context.ImportNode(itemElement, true));
@@ -92,7 +96,7 @@ namespace Godot.Serialization.Specialized
                     {
                         throw new SerializationException(child, "Invalid XML node (all nodes in a collection must be named \"item\")");
                     }
-                    add.Invoke(collection, new[] {serializer.Deserialize(child, itemType),});
+                    add.Invoke(collection, new[] {serializer.Deserialize(child, child.GetTypeToDeserialize() ?? itemType),});
                 }
                 return collection;
             }

--- a/Specialized/CollectionSerializer.cs
+++ b/Specialized/CollectionSerializer.cs
@@ -100,7 +100,7 @@ namespace Godot.Serialization.Specialized
                 }
                 serializer.Serialize(item, item.GetType()).ChildNodes
                     .Cast<XmlNode>()
-                    .ForEach(node => itemElement.AppendChild(node));
+                    .ForEach(node => itemElement.AppendChild(context.ImportNode(node, true)));
                 yield return itemElement;
             }
         }
@@ -115,12 +115,9 @@ namespace Godot.Serialization.Specialized
         protected static IEnumerable<object?> DeserializeItems(XmlNode node, Type itemType)
         {
             Serializer serializer = new();
-            foreach (XmlNode child in from XmlNode child in node.ChildNodes
-                                      where child.NodeType is XmlNodeType.Element
-                                      select child)
-            {
-                yield return child.Name is "item" ? serializer.Deserialize(child, child.GetTypeToDeserialize() ?? itemType) : throw new SerializationException(child, "Invalid XML node (all nodes in a collection must be named \"item\")");
-            }
+            return from child in node.ChildNodes.Cast<XmlNode>()
+                   where child.NodeType is XmlNodeType.Element
+                   select child.Name is "item" ? serializer.Deserialize(child, child.GetTypeToDeserialize() ?? itemType) : throw new SerializationException(child, "Invalid XML node (all nodes in a collection must be named \"item\")");
         }
     }
 }

--- a/Specialized/EnumerableSerializer.cs
+++ b/Specialized/EnumerableSerializer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -36,17 +35,7 @@ namespace Godot.Serialization.Specialized
                 XmlDocument context = new();
                 XmlElement enumerableElement = context.CreateElement("Enumerable");
                 enumerableElement.SetAttribute("Type", enumerableType.FullName);
-
-                Serializer serializer = new();
-                
-                foreach (object item in (IEnumerable)instance)
-                {
-                    XmlElement itemElement = context.CreateElement("item");
-                    serializer.Serialize(item, itemType).ChildNodes
-                        .Cast<XmlNode>()
-                        .ForEach(node => itemElement.AppendChild(context.ImportNode(node, true)));
-                    enumerableElement.AppendChild(itemElement);
-                }
+                EnumerableSerializer.SerializeItems(instance, itemType).ForEach(node => enumerableElement.AppendChild(context.ImportNode(node, true)));
                 return enumerableElement;
             }
             catch (Exception exception) when (exception is not SerializationException)


### PR DESCRIPTION
# Additions
- Add serializer for arrays (`ArraySerializer`)

# Changes
- Refactor the way `Serializer` searches for a specialized serializer for a type

# Bugfixes
- Fix `CollectionSerializer` and its inheriting serializers assuming that all items in a collection are of the same type
- Fix `CollectionSerializer` not importing an XML node when serializing