### PR TITLE
Merge v1.0.0 into stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 bin/
 obj/
-/packages/
-riderModule.iml
-/_ReSharper.Caches/
 *.sln
+.mono/
+.import/
+.idea/

--- a/AfterDeserializationAttribute.cs
+++ b/AfterDeserializationAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Godot.Serialization
+{
+    /// <summary>
+    /// Specifies that a method is to be invoked immediately after the deserialization of the object instance it is associated with.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class AfterDeserializationAttribute : Attribute
+    {
+    }
+}

--- a/AfterSerializationAttribute.cs
+++ b/AfterSerializationAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Godot.Serialization
+{
+    /// <summary>
+    /// Specifies that a method is to be invoked immediately after the serialization of the object instance it is associated with.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class AfterSerializationAttribute : Attribute
+    {
+    }
+}

--- a/GDSerializer.csproj
+++ b/GDSerializer.csproj
@@ -7,7 +7,7 @@
         <!-- Workaround as Godot does not know how to properly load NuGet packages -->
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.2.0</PackageVersion>
+        <PackageVersion>1.0.0</PackageVersion>
         <Title>GDSerializer</Title>
         <Authors>Carnagion</Authors>
         <Description>An XML (de)serialization framework for Godot's C# API.</Description>

--- a/GDSerializer.csproj
+++ b/GDSerializer.csproj
@@ -7,7 +7,7 @@
         <!-- Workaround as Godot does not know how to properly load NuGet packages -->
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.1.2</PackageVersion>
+        <PackageVersion>0.2.0</PackageVersion>
         <Title>GDSerializer</Title>
         <Authors>Carnagion</Authors>
         <Description>An XML (de)serialization framework for Godot's C# API.</Description>

--- a/README.md
+++ b/README.md
@@ -32,3 +32,25 @@ It is also recommended to enable nullability warnings in the project; however, t
     <Nullable>enable</Nullable>
 </PropertyGroup>
 ```
+
+# Usage
+
+Creating a new serializer instance:
+```csharp
+Serializer serializer = new(); // or new Serializer() for older language versions that do not recognise target-typed new()
+```
+
+Serializing an object as an XML node:
+```csharp
+XmlNode xml = serializer.Serialize(obj);
+```
+
+Deserializing an XML node as an object:
+```csharp
+object? obj = serializer.Deserialize(xml);
+```
+
+An optional type argument can be provided for both serialization and deserialization, in order to assist the serializer with figuring out the object's `Type`.  
+Generic versions of the methods can also be used.
+
+More detailed instructions on using the `Serializer` class can be found on the [GDSerializer wiki](https://github.com/Carnagion/GDSerializer/wiki).

--- a/README.md
+++ b/README.md
@@ -1,22 +1,34 @@
 # GDSerializer
 
-GDSerializer is an XML serialization (and deserialization) library developed with Godot's C# API in mind.
+**GDSerializer** is an XML serialization (and deserialization) library developed with Godot's C# API in mind.
 
 It supports (de)serialization of almost any C# type including collections and managed types, and provides an interface to create custom (de)serializers that can then be used by the default implementation to further increase its capabilities.
 
 # Installation
 
-GDSerializer is available as a [NuGet package](https://www.nuget.org/packages/GDSerializer/).  
-Simply include the following lines in a Godot project's `.csproj` file (either by editing the file manually or letting an IDE install the package):  
+**GDSerializer** is available as a [NuGet package](https://www.nuget.org/packages/GDSerializer/), which can be installed either through an IDE or by manually including the following lines in a Godot project's `.csproj` file:
 ```xml
 <ItemGroup>
-    <PackageReference Include="GDSerializer" Version="0.2.0" />
+    <PackageReference Include="GDSerializer" Version="1.0.0" />
 </ItemGroup>
 ```
+Its dependencies may need to be installed as well, in a similar fashion.
 
 Due to [a bug](https://github.com/godotengine/godot/issues/42271) in Godot, the following lines will also need to be included in the `.csproj` file to properly compile along with NuGet packages:
 ```xml
 <PropertyGroup>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+</PropertyGroup>
+```
+
+Note that **GDSerializer** targets `.NET Standard 2.1` whereas Godot projects target `.NET Framework 4.7.2` by default, so the target framework may need to be changed either through an IDE or by manually editing the `.csproj` file like so:
+```xml
+<TargetFramework>netstandard2.1</TargetFramework>
+```
+
+It is also recommended to enable nullability warnings in the project; however, this is completely optional. Again, this can be done either through an IDE or by including the following lines in the `.csproj` file:
+```xml
+<PropertyGroup>
+    <Nullable>enable</Nullable>
 </PropertyGroup>
 ```

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -87,7 +87,7 @@ namespace Godot.Serialization
                 }
 
                 // Recursively serialize properties
-                foreach (PropertyInfo property in from property in type.GetAllProperties(Serializer.instanceBindingFlags)
+                foreach (PropertyInfo property in from property in type.GetAllMembers<PropertyInfo>(Serializer.instanceBindingFlags)
                                                   where property.IsSerializable()
                                                   select property)
                 {
@@ -104,7 +104,7 @@ namespace Godot.Serialization
                 }
                 
                 // Recursively serialize fields
-                foreach (FieldInfo field in from field in type.GetAllFields(Serializer.instanceBindingFlags)
+                foreach (FieldInfo field in from field in type.GetAllMembers<FieldInfo>(Serializer.instanceBindingFlags)
                                             where field.IsSerializable()
                                             select field)
                 {

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -20,26 +20,26 @@ namespace Godot.Serialization
         {
             this.Specialized = new(19)
             {
-                {typeof(string), new SimpleSerializer()},
-                {typeof(char), new SimpleSerializer()},
-                {typeof(bool), new SimpleSerializer()},
-                {typeof(sbyte), new SimpleSerializer()},
-                {typeof(byte), new SimpleSerializer()},
-                {typeof(short), new SimpleSerializer()},
-                {typeof(ushort), new SimpleSerializer()},
-                {typeof(int), new SimpleSerializer()},
-                {typeof(uint), new SimpleSerializer()},
-                {typeof(long), new SimpleSerializer()},
-                {typeof(ulong), new SimpleSerializer()},
-                {typeof(float), new SimpleSerializer()},
-                {typeof(double), new SimpleSerializer()},
-                {typeof(decimal), new SimpleSerializer()},
+                {typeof(string), Serializer.simple},
+                {typeof(char), Serializer.simple},
+                {typeof(bool), Serializer.simple},
+                {typeof(sbyte), Serializer.simple},
+                {typeof(byte), Serializer.simple},
+                {typeof(short), Serializer.simple},
+                {typeof(ushort), Serializer.simple},
+                {typeof(int), Serializer.simple},
+                {typeof(uint), Serializer.simple},
+                {typeof(long), Serializer.simple},
+                {typeof(ulong), Serializer.simple},
+                {typeof(float), Serializer.simple},
+                {typeof(double), Serializer.simple},
+                {typeof(decimal), Serializer.simple},
                 {typeof(Array), new ArraySerializer(this)},
                 {typeof(IDictionary<,>), new DictionarySerializer(this)},
                 {typeof(ICollection<>), new CollectionSerializer(this)},
                 {typeof(IEnumerable<>), new EnumerableSerializer(this)},
-                {typeof(Vector2), new VectorSerializer()},
-                {typeof(Vector3), new VectorSerializer()},
+                {typeof(Vector2), Serializer.vector},
+                {typeof(Vector3), Serializer.vector},
             };
         }
 
@@ -49,6 +49,10 @@ namespace Godot.Serialization
         }
         
         private const BindingFlags instanceBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+
+        private static readonly SimpleSerializer simple = new();
+
+        private static readonly VectorSerializer vector = new();
 
         /// <summary>
         /// An <see cref="OrderedDictionary{TKey,TValue}"/> of specialized <see cref="ISerializer"/>s for specific <see cref="Type"/>s. These serializers will be used by the <see cref="Serializer"/> when possible.

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -120,6 +120,11 @@ namespace Godot.Serialization
                     element.AppendChild(node);
                 }
 
+                // Invoke all [AfterSerialization] methods
+                (from method in type.GetAllMembers<MethodInfo>()
+                 where method.GetCustomAttribute<AfterSerializationAttribute>() is not null
+                 select method).ForEach(method => method.Invoke(method.IsStatic ? null : instance, null));
+
                 return element;
             }
             catch (Exception exception) when (exception is not SerializationException)
@@ -214,6 +219,11 @@ namespace Godot.Serialization
                     throw new SerializationException(node, $"One or more mandatory properties or fields of {type.GetDisplayName()} were not deserialized");
                 }
 
+                // Invoke all [AfterDeserialization] methods
+                (from method in type.GetAllMembers<MethodInfo>()
+                 where method.GetCustomAttribute<AfterDeserializationAttribute>() is not null
+                 select method).ForEach(method => method.Invoke(method.IsStatic ? null : instance, null));
+                
                 return instance;
             }
             catch (Exception exception) when (exception is not SerializationException)

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -156,17 +156,6 @@ namespace Godot.Serialization
         }
 
         /// <summary>
-        /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
-        /// </summary>
-        /// <param name="instance">The <see cref="object"/> to serialize.</param>
-        /// <typeparam name="T">The <see cref="Type"/> to serialize <paramref name="instance"/> as.</typeparam>
-        /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
-        public XmlNode Serialize<T>(T instance) where T : notnull
-        {
-            return this.Serialize(instance, typeof(T));
-        }
-
-        /// <summary>
         /// Deserializes <paramref name="node"/> into an <see cref="object"/>.
         /// </summary>
         /// <param name="node">The <see cref="XmlNode"/> to deserialize.</param>
@@ -252,6 +241,17 @@ namespace Godot.Serialization
             {
                 throw new SerializationException(node, exception);
             }
+        }
+
+        /// <summary>
+        /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
+        /// </summary>
+        /// <param name="instance">The <see cref="object"/> to serialize.</param>
+        /// <typeparam name="T">The <see cref="Type"/> to serialize <paramref name="instance"/> as.</typeparam>
+        /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
+        public XmlNode Serialize<T>(T instance) where T : notnull
+        {
+            return this.Serialize(instance, typeof(T));
         }
 
         /// <summary>

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -16,6 +16,9 @@ namespace Godot.Serialization
     /// </summary>
     public class Serializer : ISerializer
     {
+        /// <summary>
+        /// Initialises a new <see cref="Serializer"/> with the default specialized serializers.
+        /// </summary>
         public Serializer()
         {
             this.Specialized = new(19)
@@ -43,6 +46,10 @@ namespace Godot.Serialization
             };
         }
 
+        /// <summary>
+        /// Initialises a new <see cref="Serializer"/> with the specified parameters.
+        /// </summary>
+        /// <param name="specializedSerializers">The specialized serializers to use when (de)serializing specific <see cref="Type"/>s.</param>
         public Serializer(OrderedDictionary<Type, ISerializer> specializedSerializers)
         {
             this.Specialized = specializedSerializers;

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -43,6 +43,7 @@ namespace Godot.Serialization
                 {typeof(IEnumerable<>), new EnumerableSerializer(this)},
                 {typeof(Vector2), Serializer.vector},
                 {typeof(Vector3), Serializer.vector},
+                {typeof(Enum), new EnumSerializer()},
             };
         }
 
@@ -64,7 +65,7 @@ namespace Godot.Serialization
         /// <summary>
         /// An <see cref="OrderedDictionary{TKey,TValue}"/> of specialized <see cref="ISerializer"/>s for specific <see cref="Type"/>s. These serializers will be used by the <see cref="Serializer"/> when possible.
         /// </summary>
-        public OrderedDictionary<Type, ISerializer> Specialized // Must be static since other serializers create new Serializer instances, and they all need access to the same dictionary
+        public OrderedDictionary<Type, ISerializer> Specialized
         {
             get;
         }

--- a/Specialized/ArraySerializer.cs
+++ b/Specialized/ArraySerializer.cs
@@ -13,6 +13,10 @@ namespace Godot.Serialization.Specialized
     /// </summary>
     public class ArraySerializer : CollectionSerializer
     {
+        public ArraySerializer(ISerializer itemSerializer) : base(itemSerializer)
+        {
+        }
+        
         /// <summary>
         /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
         /// </summary>
@@ -35,7 +39,7 @@ namespace Godot.Serialization.Specialized
                 XmlDocument context = new();
                 XmlElement arrayElement = context.CreateElement("Array");
                 arrayElement.SetAttribute("Type", $"{itemType.FullName}[]");
-                ArraySerializer.SerializeItems(instance, itemType).ForEach(node => arrayElement.AppendChild(context.ImportNode(node, true)));
+                this.SerializeItems(instance, itemType).ForEach(node => arrayElement.AppendChild(context.ImportNode(node, true)));
                 return arrayElement;
             }
             catch (Exception exception) when (exception is not SerializationException)
@@ -65,7 +69,7 @@ namespace Godot.Serialization.Specialized
 
                 IList array = Array.CreateInstance(itemType, node.ChildNodes.Count);
                 int index = 0;
-                foreach (object? item in ArraySerializer.DeserializeItems(node, itemType))
+                foreach (object? item in this.DeserializeItems(node, itemType))
                 {
                     array[index] = item;
                     index += 1;

--- a/Specialized/ArraySerializer.cs
+++ b/Specialized/ArraySerializer.cs
@@ -13,6 +13,10 @@ namespace Godot.Serialization.Specialized
     /// </summary>
     public class ArraySerializer : CollectionSerializer
     {
+        /// <summary>
+        /// Initialises a new <see cref="ArraySerializer"/> with the specified parameters.
+        /// </summary>
+        /// <param name="itemSerializer">The serializer to use when (de)serializing the array's items.</param>
         public ArraySerializer(ISerializer itemSerializer) : base(itemSerializer)
         {
         }

--- a/Specialized/ArraySerializer.cs
+++ b/Specialized/ArraySerializer.cs
@@ -34,7 +34,7 @@ namespace Godot.Serialization.Specialized
 
                 XmlDocument context = new();
                 XmlElement arrayElement = context.CreateElement("Array");
-                arrayElement.SetAttribute("Type", arrayType.FullName);
+                arrayElement.SetAttribute("Type", $"{itemType.FullName}[]");
                 ArraySerializer.SerializeItems(instance, itemType).ForEach(node => arrayElement.AppendChild(context.ImportNode(node, true)));
                 return arrayElement;
             }

--- a/Specialized/CollectionSerializer.cs
+++ b/Specialized/CollectionSerializer.cs
@@ -15,6 +15,10 @@ namespace Godot.Serialization.Specialized
     /// </summary>
     public class CollectionSerializer : ISerializer
     {
+        /// <summary>
+        /// Initialises a new <see cref="CollectionSerializer"/> with the specified parameters.
+        /// </summary>
+        /// <param name="itemSerializer">The serializer to use when (de)serializing the <see cref="ICollection{T}"/>'s items.</param>
         public CollectionSerializer(ISerializer itemSerializer)
         {
             this.itemSerializer = itemSerializer;

--- a/Specialized/DictionarySerializer.cs
+++ b/Specialized/DictionarySerializer.cs
@@ -15,6 +15,13 @@ namespace Godot.Serialization.Specialized
     /// </summary>
     public class DictionarySerializer : ISerializer
     {
+        public DictionarySerializer(ISerializer itemSerializer)
+        {
+            this.itemSerializer = itemSerializer;
+        }
+
+        private readonly ISerializer itemSerializer;
+        
         /// <summary>
         /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
         /// </summary>
@@ -43,8 +50,6 @@ namespace Godot.Serialization.Specialized
                 XmlDocument context = new();
                 XmlElement dictionaryElement = context.CreateElement("Dictionary");
                 dictionaryElement.SetAttribute("Type", dictionaryType.FullName);
-                
-                Serializer serializer = new();
 
                 foreach (object item in (IEnumerable)instance)
                 {
@@ -56,7 +61,7 @@ namespace Godot.Serialization.Specialized
                     {
                         keyElement.SetAttribute("Type", key.GetType().FullName);
                     }
-                    serializer.Serialize(key, key.GetType()).ChildNodes
+                    this.itemSerializer.Serialize(key, key.GetType()).ChildNodes
                         .Cast<XmlNode>()
                         .ForEach(node => keyElement.AppendChild(context.ImportNode(node, true)));
                     
@@ -65,7 +70,7 @@ namespace Godot.Serialization.Specialized
                     {
                         valueElement.SetAttribute("Type", value.GetType().FullName);
                     }
-                    serializer.Serialize(value, value.GetType()).ChildNodes
+                    this.itemSerializer.Serialize(value, value.GetType()).ChildNodes
                         .Cast<XmlNode>()
                         .ForEach(node => valueElement.AppendChild(context.ImportNode(node, true)));
                     

--- a/Specialized/DictionarySerializer.cs
+++ b/Specialized/DictionarySerializer.cs
@@ -15,6 +15,10 @@ namespace Godot.Serialization.Specialized
     /// </summary>
     public class DictionarySerializer : ISerializer
     {
+        /// <summary>
+        /// Initialises a new <see cref="DictionarySerializer"/> with the specified parameters.
+        /// </summary>
+        /// <param name="itemSerializer">The serializer to use when (de)serializing the <see cref="IDictionary{TKey,TValue}"/>'s items.</param>
         public DictionarySerializer(ISerializer itemSerializer)
         {
             this.itemSerializer = itemSerializer;

--- a/Specialized/EnumSerializer.cs
+++ b/Specialized/EnumSerializer.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Xml;
+
+using Godot.Serialization.Utility.Extensions;
+using Godot.Serialization.Utility.Exceptions;
+
+namespace Godot.Serialization.Specialized
+{
+    /// <summary>
+    /// A (de)serializer for enums.
+    /// </summary>
+    public class EnumSerializer : ISerializer
+    {
+        /// <summary>
+        /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
+        /// </summary>
+        /// <param name="instance">The <see cref="object"/> to serialize. It must be an array.</param>
+        /// <param name="enumType">The <see cref="Type"/> to serialize <paramref name="instance"/> as. It must be an enum type.</param>
+        /// <returns>An <see cref="XmlNode"/> that represents <paramref name="instance"/> and the serializable data stored in it.</returns>
+        /// <exception cref="SerializationException">Thrown if <paramref name="instance"/> could not be serialized due to unexpected errors or invalid input.</exception>
+        public XmlNode Serialize(object instance, Type? enumType = null)
+        {
+            enumType ??= instance.GetType();
+            if (!enumType.IsEnum)
+            {
+                throw new SerializationException(instance, $"\"{enumType.GetDisplayName()}\" cannot be serialized by {typeof(EnumerableSerializer).GetDisplayName()}");
+            }
+
+            try
+            {
+                XmlDocument context = new();
+                XmlElement element = context.CreateElement(enumType.GetDisplayName());
+                element.AppendChild(context.CreateTextNode(instance.ToString()));
+                return element;
+            }
+            catch (Exception exception) when (exception is not SerializationException)
+            {
+                throw new SerializationException(instance, exception);
+            }
+        }
+        
+        /// <summary>
+        /// Deserializes <paramref name="node"/> into an <see cref="object"/>.
+        /// </summary>
+        /// <param name="node">The <see cref="XmlNode"/> to deserialize.</param>
+        /// <param name="enumType">The <see cref="Type"/> of <see cref="object"/> to deserialize the node as. It must be an enum type</param>
+        /// <returns>An <see cref="object"/> that represents the serialized data stored in <paramref name="node"/>.</returns>
+        /// <exception cref="SerializationException">Thrown if a <see cref="Type"/> could not be inferred from <paramref name="node"/> or was invalid, or <paramref name="node"/> could not be deserialized due to unexpected errors or invalid data.</exception>
+        public object? Deserialize(XmlNode node, Type? enumType = null)
+        {
+            enumType ??= node.GetTypeToDeserialize() ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");
+            if (!enumType.IsEnum)
+            {
+                throw new SerializationException(node, $"\"{enumType.GetDisplayName()}\" cannot be deserialized by {typeof(EnumerableSerializer).GetDisplayName()}");
+            }
+            
+            if (!node.HasChildNodes)
+            {
+                throw new SerializationException(node, "Node contains no textual data");
+            }
+
+            try
+            {
+                string text = node.ChildNodes[0].InnerText;
+                return Enum.Parse(enumType, text, false);
+            }
+            catch (Exception exception) when (exception is not SerializationException)
+            {
+                throw new SerializationException(node, exception);
+            }
+        }
+    }
+}

--- a/Specialized/EnumerableSerializer.cs
+++ b/Specialized/EnumerableSerializer.cs
@@ -13,6 +13,10 @@ namespace Godot.Serialization.Specialized
     /// </summary>
     public class EnumerableSerializer : CollectionSerializer
     {
+        /// <summary>
+        /// Initialises a new <see cref="EnumerableSerializer"/> with the specified parameters.
+        /// </summary>
+        /// <param name="itemSerializer">The serializer to use when (de)serializing the <see cref="IEnumerable{T}"/>'s items.</param>
         public EnumerableSerializer(ISerializer itemSerializer) : base(itemSerializer)
         {
         }

--- a/Specialized/EnumerableSerializer.cs
+++ b/Specialized/EnumerableSerializer.cs
@@ -13,6 +13,10 @@ namespace Godot.Serialization.Specialized
     /// </summary>
     public class EnumerableSerializer : CollectionSerializer
     {
+        public EnumerableSerializer(ISerializer itemSerializer) : base(itemSerializer)
+        {
+        }
+        
         /// <summary>
         /// Serializes <paramref name="instance"/> into an <see cref="XmlNode"/>.
         /// </summary>
@@ -35,7 +39,7 @@ namespace Godot.Serialization.Specialized
                 XmlDocument context = new();
                 XmlElement enumerableElement = context.CreateElement("Enumerable");
                 enumerableElement.SetAttribute("Type", enumerableType.FullName);
-                EnumerableSerializer.SerializeItems(instance, itemType).ForEach(node => enumerableElement.AppendChild(context.ImportNode(node, true)));
+                this.SerializeItems(instance, itemType).ForEach(node => enumerableElement.AppendChild(context.ImportNode(node, true)));
                 return enumerableElement;
             }
             catch (Exception exception) when (exception is not SerializationException)

--- a/Utility/Extensions/FieldInfoExtensions.cs
+++ b/Utility/Extensions/FieldInfoExtensions.cs
@@ -19,15 +19,10 @@ namespace Godot.Serialization.Utility.Extensions
         /// <returns><see langword="true"/> if <paramref name="field"/> can be (de)serialized by an <see cref="ISerializer"/>.</returns>
         public static bool IsSerializable(this FieldInfo field)
         {
-            if (field.GetCustomAttribute<CompilerGeneratedAttribute>() is not null)
-            {
-                return false;
-            }
-            if (field.FieldType.IsPointer || FieldInfoExtensions.forbiddenTypes.Contains(field.FieldType))
-            {
-                return false;
-            }
-            return field.GetCustomAttribute<SerializeAttribute>()?.Serializable ?? true;
+            return field.GetCustomAttribute<CompilerGeneratedAttribute>() is null
+                   && !field.FieldType.IsPointer
+                   && !FieldInfoExtensions.forbiddenTypes.Contains(field.FieldType)
+                   && (field.GetCustomAttribute<SerializeAttribute>()?.Serializable ?? true);
         }
     }
 }

--- a/Utility/Extensions/PropertyInfoExtensions.cs
+++ b/Utility/Extensions/PropertyInfoExtensions.cs
@@ -19,23 +19,13 @@ namespace Godot.Serialization.Utility.Extensions
         /// <returns><see langword="true"/> if <paramref name="property"/> can be (de)serialized by an <see cref="ISerializer"/>.</returns>
         public static bool IsSerializable(this PropertyInfo property)
         {
-            if (!property.CanRead || !property.CanWrite)
-            {
-                return false;
-            }
-            if (property.GetIndexParameters().Any())
-            {
-                return false;
-            }
-            if (property.GetCustomAttribute<CompilerGeneratedAttribute>() is not null || property.GetMethod.GetCustomAttribute<CompilerGeneratedAttribute>() is not null)
-            {
-                return false;
-            }
-            if (PropertyInfoExtensions.forbiddenTypes.Contains(property.PropertyType))
-            {
-                return false;
-            }
-            return property.GetCustomAttribute<SerializeAttribute>()?.Serializable ?? true;
+            return property.CanRead
+                   && property.CanWrite
+                   && !property.GetIndexParameters().Any()
+                   && property.GetCustomAttribute<CompilerGeneratedAttribute>() is null
+                   && property.GetMethod.GetCustomAttribute<CompilerGeneratedAttribute>() is null
+                   && !PropertyInfoExtensions.forbiddenTypes.Contains(property.PropertyType)
+                   && (property.GetCustomAttribute<SerializeAttribute>()?.Serializable ?? true);
         }
     }
 }

--- a/Utility/Extensions/TypeExtensions.cs
+++ b/Utility/Extensions/TypeExtensions.cs
@@ -61,25 +61,16 @@ namespace Godot.Serialization.Utility.Extensions
         }
 
         /// <summary>
-        /// Retrieves all fields defined in <paramref name="type"/> as well as its base <see cref="Type"/>s using <paramref name="flags"/>.
+        /// Retrieves all members defined in <paramref name="type"/> as well as its base <see cref="Type"/>s using <paramref name="flags"/>.
         /// </summary>
         /// <param name="type">The <see cref="Type"/> to search in.</param>
         /// <param name="flags">The binding constraints.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of fields defined in <paramref name="type"/> and its base <see cref="Type"/>s.</returns>
-        public static IEnumerable<FieldInfo> GetAllFields(this Type type, BindingFlags flags = BindingFlags.Default)
+        /// <typeparam name="T">The <see cref="Type"/> of <see cref="MemberInfo"/> to retrieve.</typeparam>
+        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="MemberInfo"/> defined in <paramref name="type"/> and its base <see cref="Type"/>s.</returns>
+        public static IEnumerable<T> GetAllMembers<T>(this Type type, BindingFlags flags = BindingFlags.Default) where T : MemberInfo
         {
-            return type.BaseType is null ? type.GetFields(flags) : type.GetFields(flags).Concat(type.BaseType.GetAllFields(flags));
-        }
-
-        /// <summary>
-        /// Retrieves all properties defined in <paramref name="type"/> as well as its base <see cref="Type"/>s using <paramref name="flags"/>.
-        /// </summary>
-        /// <param name="type">The <see cref="Type"/> to search in.</param>
-        /// <param name="flags">The binding constraints.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of properties defined in <paramref name="type"/> and its base <see cref="Type"/>s.</returns>
-        public static IEnumerable<PropertyInfo> GetAllProperties(this Type type, BindingFlags flags = BindingFlags.Default)
-        {
-            return type.BaseType is null ? type.GetProperties(flags) : type.GetProperties(flags).Concat(type.BaseType.GetAllProperties(flags));
+            IEnumerable<T> members = type.GetMembers(flags).OfType<T>();
+            return type.BaseType is null ? members : members.Concat(type.BaseType.GetAllMembers<T>(flags));
         }
 
         /// <summary>


### PR DESCRIPTION
# Additions
- Add serializer for enums
- Add support for calling methods after serialization and deserialization

# Changes
- `Serializer` no longer uses a static dictionary
  - Instead uses an instance one passed during construction
- Serializer classes that depend on another serializer now require an `ISerializer` reference during construction
- `Serializer` no longer creates multiple instances of `SimpleSerializer` and `VectorSerializer`