### PR TITLE
Merge v1.1.0 into stable

### DIFF
--- a/GDSerializer.csproj
+++ b/GDSerializer.csproj
@@ -4,6 +4,7 @@
         <RootNamespace>Godot.Serialization</RootNamespace>
         <LangVersion>default</LangVersion>
         <Nullable>enable</Nullable>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- Workaround as Godot does not know how to properly load NuGet packages -->
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -13,15 +14,6 @@
         <Description>An XML (de)serialization framework for Godot's C# API.</Description>
         <RepositoryUrl>https://github.com/Carnagion/GDSerializer</RepositoryUrl>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-        <DocumentationFile>.\.mono\temp\bin\Debug\GDSerializer.xml</DocumentationFile>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'ExportDebug' ">
-        <DocumentationFile>.\.mono\temp\bin\ExportDebug\GDSerializer.xml</DocumentationFile>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)' == 'ExportRelease' ">
-        <DocumentationFile>.\.mono\temp\bin\ExportRelease\GDSerializer.xml</DocumentationFile>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Carnagion.MoreLinq" Version="1.3.0" />

--- a/GDSerializer.csproj
+++ b/GDSerializer.csproj
@@ -8,7 +8,7 @@
         <!-- Workaround as Godot does not know how to properly load NuGet packages -->
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>1.0.0</PackageVersion>
+        <PackageVersion>1.1.0</PackageVersion>
         <Title>GDSerializer</Title>
         <Authors>Carnagion</Authors>
         <Description>An XML (de)serialization framework for Godot's C# API.</Description>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It supports (de)serialization of almost any C# type including collections and ma
 **GDSerializer** is available as a [NuGet package](https://www.nuget.org/packages/GDSerializer/), which can be installed either through an IDE or by manually including the following lines in a Godot project's `.csproj` file:
 ```xml
 <ItemGroup>
-    <PackageReference Include="GDSerializer" Version="1.0.0" />
+    <PackageReference Include="GDSerializer" Version="1.1.0" />
 </ItemGroup>
 ```
 Its dependencies may need to be installed as well, in a similar fashion.

--- a/SerializationException.cs
+++ b/SerializationException.cs
@@ -3,7 +3,7 @@ using System.Xml;
 
 using Godot.Serialization.Utility.Extensions;
 
-namespace Godot.Serialization.Utility.Exceptions
+namespace Godot.Serialization
 {
     /// <summary>
     /// The exception that is thrown when there is a failed attempt at serializing an <see cref="object"/> or deserializing an <see cref="XmlNode"/>.

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -304,28 +304,28 @@ namespace Godot.Serialization
 
         private bool TryGetSpecialSerializerForType(Type type, [NotNullWhen(true)] out ISerializer? serializer)
         {
-            if (this.specialized.TryGetValue(type, out serializer))
+            if (this.Specialized.TryGetValue(type, out serializer))
             {
                 return true;
             }
             if (type.IsGenericType)
             {
-                Type? match = this.specialized.Keys.FirstOrDefault(type.IsExactlyGenericType);
-                match ??= this.specialized.Keys.FirstOrDefault(type.DerivesFromGenericType);
+                Type? match = this.Specialized.Keys.FirstOrDefault(type.IsExactlyGenericType);
+                match ??= this.Specialized.Keys.FirstOrDefault(type.DerivesFromGenericType);
                 if (match is null)
                 {
                     return false;
                 }
-                serializer = this.specialized[match];
+                serializer = this.Specialized[match];
             }
             else
             {
-                Type? match = this.specialized.Keys.FirstOrDefault(key => key.IsAssignableFrom(type));
+                Type? match = this.Specialized.Keys.FirstOrDefault(key => key.IsAssignableFrom(type));
                 if (match is null)
                 {
                     return false;
                 }
-                serializer = this.specialized[match];
+                serializer = this.Specialized[match];
             }
             return true;
         }
@@ -333,7 +333,7 @@ namespace Godot.Serialization
         private bool TryDeserializeReferencedNode(XmlNode node, out object? instance)
         {
             instance = null;
-            if (!this.referenceSources.Any())
+            if (!this.ReferenceSources.Any())
             {
                 return false;
             }
@@ -346,7 +346,7 @@ namespace Godot.Serialization
             {
                 return true;
             }
-            XmlNode referencedNode = (from source in this.referenceSources
+            XmlNode referencedNode = (from source in this.ReferenceSources
                                       select source.SelectSingleNode($"*[@Id='{referencedId}']")).FirstOrDefault() ?? throw new SerializationException(node, $"Referenced XML node with ID \"{referencedId}\" not found");
             instance = this.Deserialize(referencedNode);
             return true;

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Xml;
@@ -18,7 +19,8 @@ namespace Godot.Serialization
         /// <summary>
         /// Initialises a new <see cref="Serializer"/> with the default specialized serializers.
         /// </summary>
-        public Serializer()
+        /// <param name="referenceSources">An array of <see cref="XmlNode"/>s to use when deserializing <see cref="XmlNode"/>s that refer other <see cref="XmlNode"/>s through an ID.</param>
+        public Serializer(params XmlNode[] referenceSources)
         {
             this.specialized = new(19)
             {
@@ -44,15 +46,20 @@ namespace Godot.Serialization
                 {typeof(Vector3), Serializer.vector},
                 {typeof(Enum), new EnumSerializer()},
             };
+            this.referenceSources = referenceSources;
+            this.referenceStorage = referenceSources.Any() ? new() : null!;
         }
 
         /// <summary>
         /// Initialises a new <see cref="Serializer"/> with the specified parameters.
         /// </summary>
         /// <param name="specializedSerializers">The specialized serializers to use when (de)serializing specific <see cref="Type"/>s.</param>
-        public Serializer(OrderedDictionary<Type, ISerializer> specializedSerializers)
+        /// <param name="referenceSources">An array of <see cref="XmlNode"/>s to use when deserializing <see cref="XmlNode"/>s that refer other <see cref="XmlNode"/>s through an ID.</param>
+        public Serializer(OrderedDictionary<Type, ISerializer> specializedSerializers, params XmlNode[] referenceSources)
         {
             this.specialized = specializedSerializers;
+            this.referenceSources = referenceSources;
+            this.referenceStorage = referenceSources.Any() ? new() : null!;
         }
         
         private const BindingFlags instanceBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
@@ -63,6 +70,10 @@ namespace Godot.Serialization
 
         private readonly OrderedDictionary<Type, ISerializer> specialized;
 
+        private readonly XmlNode[] referenceSources;
+
+        private readonly Dictionary<string, object?> referenceStorage;
+
         /// <summary>
         /// Specialized <see cref="ISerializer"/>s for specific <see cref="Type"/>s. These serializers will be used by the <see cref="Serializer"/> when possible.
         /// </summary>
@@ -71,6 +82,17 @@ namespace Godot.Serialization
             get
             {
                 return this.specialized;
+            }
+        }
+
+        /// <summary>
+        /// An <see cref="IEnumerable{T}"/> of <see cref="XmlNode"/>s that contain <see cref="XmlNode"/>s with IDs referenced by other <see cref="XmlNode"/>s.
+        /// </summary>
+        public IEnumerable<XmlNode> ReferenceSources
+        {
+            get
+            {
+                return this.referenceSources;
             }
         }
 
@@ -86,8 +108,7 @@ namespace Godot.Serialization
             type ??= instance.GetType();
             
             // Use a more specialized serializer if possible
-            ISerializer? serializer = this.GetSpecialSerializerForType(type);
-            if (serializer is not null)
+            if (this.TryGetSpecialSerializerForType(type, out ISerializer? serializer))
             {
                 return serializer.Serialize(instance, type);
             }
@@ -174,10 +195,15 @@ namespace Godot.Serialization
             }
             
             type ??= node.GetTypeToDeserialize() ?? throw new SerializationException(node, $"No {nameof(Type)} found to instantiate");
+
+            // Use a previously deserialized node if referenced
+            if (this.TryDeserializeReferencedNode(node, out object? referenced))
+            {
+                return referenced;
+            }
             
             // Use a more specialized deserializer if possible
-            ISerializer? serializer = this.GetSpecialSerializerForType(type);
-            if (serializer is not null)
+            if (this.TryGetSpecialSerializerForType(type, out ISerializer? serializer))
             {
                 return serializer.Deserialize(node, type);
             }
@@ -239,6 +265,13 @@ namespace Godot.Serialization
                  where method.GetCustomAttribute<AfterDeserializationAttribute>() is not null
                  select method).ForEach(method => method.Invoke(method.IsStatic ? null : instance, null));
                 
+                // Add deserialized instance to reference storage if it has an ID
+                string? id = node.Attributes?["Id"]?.InnerText;
+                if (id is not null)
+                {
+                    this.referenceStorage.Add(id, instance);
+                }
+                
                 return instance;
             }
             catch (Exception exception) when (exception is not SerializationException)
@@ -269,31 +302,54 @@ namespace Godot.Serialization
             return (T?)this.Deserialize(node, typeof(T));
         }
 
-        private ISerializer? GetSpecialSerializerForType(Type type)
+        private bool TryGetSpecialSerializerForType(Type type, [NotNullWhen(true)] out ISerializer? serializer)
         {
-            ISerializer? serializer = this.Specialized.GetValueOrDefault(type);
-            if (serializer is not null)
+            if (this.specialized.TryGetValue(type, out serializer))
             {
-                return serializer;
+                return true;
             }
             if (type.IsGenericType)
             {
-                Type? match = this.Specialized.Keys.FirstOrDefault(type.IsExactlyGenericType);
-                match ??= this.Specialized.Keys.FirstOrDefault(type.DerivesFromGenericType);
-                if (match is not null)
+                Type? match = this.specialized.Keys.FirstOrDefault(type.IsExactlyGenericType);
+                match ??= this.specialized.Keys.FirstOrDefault(type.DerivesFromGenericType);
+                if (match is null)
                 {
-                    return this.Specialized[match];
+                    return false;
                 }
+                serializer = this.specialized[match];
             }
             else
             {
-                Type? match = this.Specialized.Keys.FirstOrDefault(key => key.IsAssignableFrom(type));
-                if (match is not null)
+                Type? match = this.specialized.Keys.FirstOrDefault(key => key.IsAssignableFrom(type));
+                if (match is null)
                 {
-                    serializer = this.Specialized[match];
+                    return false;
                 }
+                serializer = this.specialized[match];
             }
-            return serializer;
+            return true;
+        }
+
+        private bool TryDeserializeReferencedNode(XmlNode node, out object? instance)
+        {
+            instance = null;
+            if (!this.referenceSources.Any())
+            {
+                return false;
+            }
+            string? referencedId = node.Attributes?["Refer"]?.InnerText;
+            if (referencedId is null)
+            {
+                return false;
+            }
+            if (this.referenceStorage.TryGetValue(referencedId, out instance))
+            {
+                return true;
+            }
+            XmlNode referencedNode = (from source in this.referenceSources
+                                      select source.SelectSingleNode($"*[@Id='{referencedId}']")).FirstOrDefault() ?? throw new SerializationException(node, $"Referenced XML node with ID \"{referencedId}\" not found");
+            instance = this.Deserialize(referencedNode);
+            return true;
         }
     }
 }

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -6,7 +6,6 @@ using System.Xml;
 
 using Godot.Serialization.Specialized;
 using Godot.Serialization.Utility;
-using Godot.Serialization.Utility.Exceptions;
 using Godot.Serialization.Utility.Extensions;
 
 namespace Godot.Serialization

--- a/Serializer.cs
+++ b/Serializer.cs
@@ -20,7 +20,7 @@ namespace Godot.Serialization
         /// </summary>
         public Serializer()
         {
-            this.Specialized = new(19)
+            this.specialized = new(19)
             {
                 {typeof(string), Serializer.simple},
                 {typeof(char), Serializer.simple},
@@ -52,7 +52,7 @@ namespace Godot.Serialization
         /// <param name="specializedSerializers">The specialized serializers to use when (de)serializing specific <see cref="Type"/>s.</param>
         public Serializer(OrderedDictionary<Type, ISerializer> specializedSerializers)
         {
-            this.Specialized = specializedSerializers;
+            this.specialized = specializedSerializers;
         }
         
         private const BindingFlags instanceBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
@@ -61,12 +61,17 @@ namespace Godot.Serialization
 
         private static readonly VectorSerializer vector = new();
 
+        private readonly OrderedDictionary<Type, ISerializer> specialized;
+
         /// <summary>
-        /// An <see cref="OrderedDictionary{TKey,TValue}"/> of specialized <see cref="ISerializer"/>s for specific <see cref="Type"/>s. These serializers will be used by the <see cref="Serializer"/> when possible.
+        /// Specialized <see cref="ISerializer"/>s for specific <see cref="Type"/>s. These serializers will be used by the <see cref="Serializer"/> when possible.
         /// </summary>
-        public OrderedDictionary<Type, ISerializer> Specialized
+        public IReadOnlyDictionary<Type, ISerializer> Specialized
         {
-            get;
+            get
+            {
+                return this.specialized;
+            }
         }
 
         /// <summary>

--- a/Specialized/ArraySerializer.cs
+++ b/Specialized/ArraySerializer.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Linq;
 using System.Xml;
 
-using Godot.Serialization.Utility.Exceptions;
 using Godot.Serialization.Utility.Extensions;
 
 namespace Godot.Serialization.Specialized

--- a/Specialized/CollectionSerializer.cs
+++ b/Specialized/CollectionSerializer.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Xml;
 
-using Godot.Serialization.Utility.Exceptions;
 using Godot.Serialization.Utility.Extensions;
 
 namespace Godot.Serialization.Specialized

--- a/Specialized/DictionarySerializer.cs
+++ b/Specialized/DictionarySerializer.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Xml;
 
-using Godot.Serialization.Utility.Exceptions;
 using Godot.Serialization.Utility.Extensions;
 
 namespace Godot.Serialization.Specialized

--- a/Specialized/DictionarySerializer.cs
+++ b/Specialized/DictionarySerializer.cs
@@ -118,8 +118,6 @@ namespace Godot.Serialization.Specialized
                 {
                     dictionaryType = typeof(Dictionary<,>).MakeGenericType(keyType, valueType);
                 }
-                
-                Serializer serializer = new();
 
                 object dictionary = Activator.CreateInstance(dictionaryType, true) ?? throw new SerializationException(node, $"Unable to instantiate {dictionaryType.GetDisplayName()}");
                 foreach (XmlNode child in from XmlNode child in node.ChildNodes
@@ -138,7 +136,7 @@ namespace Godot.Serialization.Specialized
                         .Cast<XmlNode>()
                         .SingleOrDefault(grandchild => grandchild.Name == "value") ?? throw new SerializationException(child, "No value node present");
 
-                    add.Invoke(dictionary, new[] {serializer.Deserialize(key, key.GetTypeToDeserialize() ?? keyType), serializer.Deserialize(value, value.GetTypeToDeserialize() ?? valueType),});
+                    add.Invoke(dictionary, new[] {this.itemSerializer.Deserialize(key, key.GetTypeToDeserialize() ?? keyType), this.itemSerializer.Deserialize(value, value.GetTypeToDeserialize() ?? valueType),});
                 }
                 return dictionary;
             }

--- a/Specialized/EnumSerializer.cs
+++ b/Specialized/EnumSerializer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Xml;
 
 using Godot.Serialization.Utility.Extensions;
-using Godot.Serialization.Utility.Exceptions;
 
 namespace Godot.Serialization.Specialized
 {

--- a/Specialized/EnumerableSerializer.cs
+++ b/Specialized/EnumerableSerializer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 
-using Godot.Serialization.Utility.Exceptions;
 using Godot.Serialization.Utility.Extensions;
 
 namespace Godot.Serialization.Specialized

--- a/Specialized/SimpleSerializer.cs
+++ b/Specialized/SimpleSerializer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Xml;
 
-using Godot.Serialization.Utility.Exceptions;
 using Godot.Serialization.Utility.Extensions;
 
 namespace Godot.Serialization.Specialized

--- a/Specialized/VectorSerializer.cs
+++ b/Specialized/VectorSerializer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Xml;
 
-using Godot.Serialization.Utility.Exceptions;
 using Godot.Serialization.Utility.Extensions;
 
 namespace Godot.Serialization.Specialized


### PR DESCRIPTION
# Additions
- Add support for referencing other XML nodes using IDs during deserialization

# Changes
- Tweak namespaces

# Bugfixes
- Make `DictionarySerializer` use its item serializer (passed in during construction) as intended instead of using a regular `Serializer`