### PR TITLE
Merge v2.0.3 into stable

### DIFF
--- a/GDSerializer.csproj
+++ b/GDSerializer.csproj
@@ -8,7 +8,7 @@
         <!-- Workaround as Godot does not know how to properly load NuGet packages -->
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>2.0.2</PackageVersion>
+        <PackageVersion>2.0.3</PackageVersion>
         <Title>GDSerializer</Title>
         <Authors>Carnagion</Authors>
         <Description>An XML (de)serialization framework for Godot's C# API.</Description>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It supports (de)serialization of almost any C# type including collections and ma
 **GDSerializer** is available as a [NuGet package](https://www.nuget.org/packages/GDSerializer/), which can be installed either through an IDE or by manually including the following lines in a Godot project's `.csproj` file:
 ```xml
 <ItemGroup>
-    <PackageReference Include="GDSerializer" Version="2.0.2"/>
+    <PackageReference Include="GDSerializer" Version="2.0.3"/>
 </ItemGroup>
 ```
 Its dependencies may need to be installed as well, in a similar fashion.

--- a/Serialization/Serializer.cs
+++ b/Serialization/Serializer.cs
@@ -132,10 +132,10 @@ namespace Godot.Serialization
         {
             type ??= instance.GetType();
             
-            XmlNode element;
-            
             try
             {
+                XmlNode element;
+                
                 // Use a more specialized serializer if possible
                 if (this.TryGetSpecialSerializerForType(type, out ISerializer? serializer))
                 {
@@ -145,22 +145,10 @@ namespace Godot.Serialization
                 {
                     XmlDocument context = new();
                     
-                    // Use the "Type" attribute if generic or nested type as ` and + are not allowed as XML node names
-                    if (type.IsGenericType)
-                    {
-                        element = context.CreateElement("Generic");
-                        ((XmlElement)element).SetAttribute("Type", type.GetDisplayName().XMLEscape());
-                    }
-                    else if (type.IsNested)
-                    {
-                        element = context.CreateElement("Nested");
-                        ((XmlElement)element).SetAttribute("Type", type.GetDisplayName().XMLEscape());
-                    }
-                    else
-                    {
-                        element = context.CreateElement(type.GetDisplayName());
-                    }
+                    element = context.CreateElement("Instance");
+                    ((XmlElement)element).SetAttribute("Type", type.GetDisplayName().XMLEscape());
                     
+                    // Serialize fields and properties
                     this.SerializeMembers(instance, type).ForEach(pair => element.AppendChild(context.ImportNode(pair.Item1, true)));
                 }
                 

--- a/Serialization/Serializer.cs
+++ b/Serialization/Serializer.cs
@@ -144,7 +144,7 @@ namespace Godot.Serialization
                 else
                 {
                     XmlDocument context = new();
-                
+                    
                     // Use the "Type" attribute if generic or nested type as ` and + are not allowed as XML node names
                     if (type.IsGenericType)
                     {
@@ -160,7 +160,7 @@ namespace Godot.Serialization
                     {
                         element = context.CreateElement(type.GetDisplayName());
                     }
-                
+                    
                     this.SerializeMembers(instance, type).ForEach(pair => element.AppendChild(context.ImportNode(pair.Item1, true)));
                 }
                 

--- a/Serialization/Serializer.cs
+++ b/Serialization/Serializer.cs
@@ -143,7 +143,7 @@ namespace Godot.Serialization
                 {
                     XmlDocument context = new();
                     element = context.CreateElement("Object");
-                    ((XmlElement)element).SetAttribute("Type", type.GetDisplayName().XMLEscape());
+                    ((XmlElement)element).SetAttribute("Type", type.GetDisplayName());
                     
                     // Serialize fields and properties
                     this.SerializeMembers(instance, type).ForEach(pair => element.AppendChild(context.ImportNode(pair.Item1, true)));

--- a/Serialization/Specialized/ArraySerializer.cs
+++ b/Serialization/Specialized/ArraySerializer.cs
@@ -39,7 +39,7 @@ namespace Godot.Serialization.Specialized
             
             XmlDocument context = new();
             XmlElement arrayElement = context.CreateElement("Array");
-            arrayElement.SetAttribute("Type", $"{itemType.GetDisplayName().XMLEscape()}[]");
+            arrayElement.SetAttribute("Type", $"{itemType.GetDisplayName()}[]");
             this.SerializeItems(instance, itemType).ForEach(node => arrayElement.AppendChild(context.ImportNode(node, true)));
             return arrayElement;
         }

--- a/Serialization/Specialized/CollectionSerializer.cs
+++ b/Serialization/Specialized/CollectionSerializer.cs
@@ -50,7 +50,7 @@ namespace Godot.Serialization.Specialized
             
             XmlDocument context = new();
             XmlElement collectionElement = context.CreateElement("Collection");
-            collectionElement.SetAttribute("Type", collectionType.GetDisplayName().XMLEscape());
+            collectionElement.SetAttribute("Type", collectionType.GetDisplayName());
             this.SerializeItems(instance, itemType).ForEach(node => collectionElement.AppendChild(context.ImportNode(node, true)));
             return collectionElement;
         }
@@ -97,7 +97,7 @@ namespace Godot.Serialization.Specialized
                 XmlElement itemElement = context.CreateElement("item");
                 if (item.GetType() != itemType)
                 {
-                    itemElement.SetAttribute("Type", item.GetType().GetDisplayName().XMLEscape());
+                    itemElement.SetAttribute("Type", item.GetType().GetDisplayName());
                 }
                 this.ItemSerializer.Serialize(item, item.GetType()).ChildNodes
                     .Cast<XmlNode>()

--- a/Serialization/Specialized/DictionarySerializer.cs
+++ b/Serialization/Specialized/DictionarySerializer.cs
@@ -50,7 +50,7 @@ namespace Godot.Serialization.Specialized
             
             XmlDocument context = new();
             XmlElement dictionaryElement = context.CreateElement("Dictionary");
-            dictionaryElement.SetAttribute("Type", dictionaryType.GetDisplayName().XMLEscape());
+            dictionaryElement.SetAttribute("Type", dictionaryType.GetDisplayName());
             
             foreach (object item in (IEnumerable)instance)
             {
@@ -60,7 +60,7 @@ namespace Godot.Serialization.Specialized
                 XmlElement keyElement = context.CreateElement("key");
                 if (key.GetType() != keyType)
                 {
-                    keyElement.SetAttribute("Type", key.GetType().GetDisplayName().XMLEscape());
+                    keyElement.SetAttribute("Type", key.GetType().GetDisplayName());
                 }
                 this.itemSerializer.Serialize(key, key.GetType()).ChildNodes
                     .Cast<XmlNode>()
@@ -69,7 +69,7 @@ namespace Godot.Serialization.Specialized
                 XmlElement valueElement = context.CreateElement("value");
                 if (value.GetType() != valueType)
                 {
-                    valueElement.SetAttribute("Type", value.GetType().GetDisplayName().XMLEscape());
+                    valueElement.SetAttribute("Type", value.GetType().GetDisplayName());
                 }
                 this.itemSerializer.Serialize(value, value.GetType()).ChildNodes
                     .Cast<XmlNode>()

--- a/Serialization/Specialized/EnumerableSerializer.cs
+++ b/Serialization/Specialized/EnumerableSerializer.cs
@@ -39,7 +39,7 @@ namespace Godot.Serialization.Specialized
             
             XmlDocument context = new();
             XmlElement enumerableElement = context.CreateElement("Enumerable");
-            enumerableElement.SetAttribute("Type", enumerableType.GetDisplayName().XMLEscape());
+            enumerableElement.SetAttribute("Type", enumerableType.GetDisplayName());
             this.SerializeItems(instance, itemType).ForEach(node => enumerableElement.AppendChild(context.ImportNode(node, true)));
             return enumerableElement;
         }

--- a/Serialization/Specialized/NodeSerializer.cs
+++ b/Serialization/Specialized/NodeSerializer.cs
@@ -37,7 +37,7 @@ namespace Godot.Serialization.Specialized
             
             XmlDocument context = new();
             
-            XmlElement element = context.CreateElement("Instance");
+            XmlElement element = context.CreateElement("Node");
             element.SetAttribute("Type", nodeType.GetDisplayName().XMLEscape());
             
             Serializer defaultSerializer = (Serializer)this.ItemSerializer;

--- a/Serialization/Specialized/NodeSerializer.cs
+++ b/Serialization/Specialized/NodeSerializer.cs
@@ -38,7 +38,7 @@ namespace Godot.Serialization.Specialized
             XmlDocument context = new();
             
             XmlElement element = context.CreateElement("Node");
-            element.SetAttribute("Type", nodeType.GetDisplayName().XMLEscape());
+            element.SetAttribute("Type", nodeType.GetDisplayName());
             
             Serializer defaultSerializer = (Serializer)this.ItemSerializer;
             defaultSerializer.SerializeMembers(nodeInstance, nodeType).ForEach(pair => element.AppendChild(context.ImportNode(pair.Item1, true)));

--- a/Serialization/Specialized/NodeSerializer.cs
+++ b/Serialization/Specialized/NodeSerializer.cs
@@ -37,22 +37,8 @@ namespace Godot.Serialization.Specialized
             
             XmlDocument context = new();
             
-            // Use the "Type" attribute if generic or nested type as ` and + are not allowed as XML node names
-            XmlElement element;
-            if (nodeType.IsGenericType)
-            {
-                element = context.CreateElement("Generic");
-                element.SetAttribute("Type", nodeType.GetDisplayName().XMLEscape());
-            }
-            else if (nodeType.IsNested)
-            {
-                element = context.CreateElement("Nested");
-                element.SetAttribute("Type", nodeType.GetDisplayName().XMLEscape());
-            }
-            else
-            {
-                element = context.CreateElement(nodeType.GetDisplayName());
-            }
+            XmlElement element = context.CreateElement("Instance");
+            element.SetAttribute("Type", nodeType.GetDisplayName().XMLEscape());
             
             Serializer defaultSerializer = (Serializer)this.ItemSerializer;
             defaultSerializer.SerializeMembers(nodeInstance, nodeType).ForEach(pair => element.AppendChild(context.ImportNode(pair.Item1, true)));

--- a/Serialization/Specialized/NodeSerializer.cs
+++ b/Serialization/Specialized/NodeSerializer.cs
@@ -53,9 +53,8 @@ namespace Godot.Serialization.Specialized
             {
                 element = context.CreateElement(nodeType.GetDisplayName());
             }
-
-            Serializer defaultSerializer = (Serializer)this.ItemSerializer;
             
+            Serializer defaultSerializer = (Serializer)this.ItemSerializer;
             defaultSerializer.SerializeMembers(nodeInstance, nodeType).ForEach(pair => element.AppendChild(context.ImportNode(pair.Item1, true)));
             
             if (nodeInstance.GetChildCount() is 0)
@@ -90,7 +89,7 @@ namespace Godot.Serialization.Specialized
             {
                 node.RemoveChild(childrenElement);
             }
-
+            
             Serializer defaultSerializer = (Serializer)this.ItemSerializer;
             
             object instance = Activator.CreateInstance(nodeType, true) ?? throw new SerializationException(node, $"Unable to instantiate {nodeType.GetDisplayName()}");


### PR DESCRIPTION
# Bugfixes
- `Serializer` (de)serializes members properly using their exact type
- `Serializer` no longer checks if a property's `get` accessor is not compiler-generated for it to be considered serializable

# Tweaks
- `Serializer` now always uses the `Type` attribute when serializing objects
- Remove usage of `XMLEscape()` as the C# XML API  does it automatically